### PR TITLE
openssl 3 에서 RC2_CBC 알고리즘 지원 문제 

### DIFF
--- a/hometaxbot/scraper/__init__.py
+++ b/hometaxbot/scraper/__init__.py
@@ -59,7 +59,8 @@ class HometaxScraper:
             validate_cert_expiry(sign)
 
         if len(cert_paths) == 1:
-            p = subprocess.Popen(['openssl', 'pkcs12', '-info', '-in', cert_paths[0], '-nodes', '-nocerts', '-passin',
+            p = subprocess.Popen(['openssl', 'pkcs12', '-info', '-provider', 'legacy', '-provider', 'default',
+                                  '-in', cert_paths[0], '-nodes', '-nocerts', '-passin',
                                   f'pass:{prikey_password}'], stdout=subprocess.PIPE)
             prikey_dumped, _ = p.communicate()
             ID_KISA_NPKI_RAND_NUM = '1.2.410.200004.10.1.1.3'
@@ -116,7 +117,8 @@ class HometaxScraper:
             sign = load_cert(files, prikey_password)
 
         if len(cert_paths) == 1:
-            p = subprocess.Popen(['openssl', 'pkcs12', '-info', '-in', cert_paths[0], '-nodes', '-nocerts', '-passin',
+            p = subprocess.Popen(['openssl', 'pkcs12', '-info', '-provider', 'legacy', '-provider', 'default',
+                                  '-in', cert_paths[0], '-nodes', '-nocerts', '-passin',
                                   f'pass:{prikey_password}'], stdout=subprocess.PIPE)
             prikey_dumped, _ = p.communicate()
             ID_KISA_NPKI_RAND_NUM = '1.2.410.200004.10.1.1.3'


### PR DESCRIPTION
openssl 3에서 RC2_CBC 알고리즘은 '-provider legacy' 옵션이 필요합니다.

> -legacy
> 
> Use legacy mode of operation and automatically load the legacy provider. If OpenSSL is not installed system-wide, it is necessary to also use, for example, -provider-path ./providers or to set the environment variable OPENSSL_MODULES to point to the directory where the providers can be found.
> 
> In the legacy mode, the default algorithm for certificate encryption is RC2_CBC or 3DES_CBC depending on whether the RC2 cipher is enabled in the build. The default algorithm for private key encryption is 3DES_CBC. If the legacy option is not specified, then the legacy provider is not loaded and the default encryption algorithm for both certificates and private keys is AES_256_CBC with PBKDF2 for key derivation.
> 

관련 문서입니다.
https://docs.openssl.org/3.0/man1/openssl-pkcs12/#options
https://datapeak.tistory.com/44

좋은 라이브러리 공개해주셔서 감사합니다.