### PR TITLE
연말정산 금액 포함 확인

### DIFF
--- a/hometaxbot/scraper/reports.py
+++ b/hometaxbot/scraper/reports.py
@@ -40,6 +40,10 @@ def 전자신고결과조회(scraper: HometaxScraper, begin: date, end: date):
                     "pageSize": "0",
                     "pageNum": "0",
                 }):
+            if 세목코드 == '14' and element['txnrmYm'][4:] == '02':
+                원천_연말정산금액 = 신고서_원천세_연말정산금액(scraper, models.세목코드.원천세, element['rtnCvaId'])
+                element['stasAmt'] = element['stasAmt'] - int(원천_연말정산금액)
+
             yield model_from_hometax_json(models.전자신고결과조회, element)
 
 
@@ -284,6 +288,12 @@ def 신고서_납부서(scraper: HometaxScraper, 세목: models.세목코드, be
                     ),
                     납부서_pdf=BytesIO(res.content),
                 )
+
+
+def 신고서_원천세_연말정산금액(scraper: HometaxScraper, 세목: models.세목코드, 접수번호: str):
+    clip_uid = clipreport_uid(scraper, 세목, 접수번호)
+    data = clip_data(scraper, clip_uid)
+    return get_원천세_연말정산금액(data)
 
 
 def s_time():

--- a/tests/test_scrape.py
+++ b/tests/test_scrape.py
@@ -73,3 +73,13 @@ class TestScrape(unittest.TestCase):
             clip_uid = reports.clipreport_uid(scraper, report.세목코드, report.접수번호)
             data = reports.clip_data(scraper, clip_uid)
             print(data)
+
+    def test_연말정산금액_for_pdf(self):
+        scraper = HometaxScraper()
+        scraper.login_with_cert(testdata.CORP_CERT, testdata.CORP_PASSWORD)
+
+        for report in reports.세금신고내역_원천세(scraper, date(2025, 1, 1), date(2025, 6, 19)):
+            clip_uid = reports.clipreport_uid(scraper, report.세목코드, report.접수번호)
+            data = reports.clip_data(scraper, clip_uid)
+            원천_연말정산금액 = reports.get_원천세_연말정산금액(data)
+            print(f"원천_연말정산금액 :{원천_연말정산금액}")


### PR DESCRIPTION
원천징수이행상황 신고서의 pdf 데이터를 확인하여 파싱 후
해당 데이터에 포함되어있는 연말정산 총지급액분을 확인 할 수 있도록 
tests/test_scrape.py > test_연말정산금액_for_pdf 테스트코드 작성 하였습니다.